### PR TITLE
fix: update resource checking methods to include report template

### DIFF
--- a/service/core/src/main/java/cloud/xcan/angus/core/tester/application/cmd/report/impl/ReportCmdImpl.java
+++ b/service/core/src/main/java/cloud/xcan/angus/core/tester/application/cmd/report/impl/ReportCmdImpl.java
@@ -136,7 +136,7 @@ public class ReportCmdImpl extends CommCmd<Report, Long> implements ReportCmd {
         // Check the report exists
         reportQuery.checkExists(report.getProjectId(), report.getName(), report.getVersion());
         // Check the report resource exists
-        resourceDb = reportQuery.checkAndFindResource(report.getProjectId(),
+        resourceDb = reportQuery.checkAndFindResource(report.getTemplate(), report.getProjectId(),
             filter.getTargetType(), filter.getTargetId());
         // Check the quota limit
         reportQuery.checkQuota();

--- a/service/core/src/main/java/cloud/xcan/angus/core/tester/application/query/report/ReportQuery.java
+++ b/service/core/src/main/java/cloud/xcan/angus/core/tester/application/query/report/ReportQuery.java
@@ -46,8 +46,8 @@ public interface ReportQuery {
 
   void checkExists(Long projectId, String name, String version);
 
-  ActivityResource checkAndFindResource(Long projectId, CombinedTargetType targetType,
-      Long targetId);
+  ActivityResource checkAndFindResource(ReportTemplate template, Long projectId,
+      CombinedTargetType targetType, Long targetId);
 
   void checkQuota();
 

--- a/service/core/src/main/java/cloud/xcan/angus/core/tester/application/query/report/impl/ReportQueryImpl.java
+++ b/service/core/src/main/java/cloud/xcan/angus/core/tester/application/query/report/impl/ReportQueryImpl.java
@@ -198,9 +198,6 @@ public class ReportQueryImpl implements ReportQuery {
   private ScenarioTestQuery scenarioTestQuery;
 
   @Resource
-  private ScriptQuery scriptQuery;
-
-  @Resource
   private KanbanEfficiencyQuery kanbanEfficiencyQuery;
 
   @Resource
@@ -385,10 +382,10 @@ public class ReportQueryImpl implements ReportQuery {
   }
 
   @Override
-  public ActivityResource checkAndFindResource(Long projectId,
+  public ActivityResource checkAndFindResource(ReportTemplate template, Long projectId,
       CombinedTargetType targetType, Long targetId) {
-    long count = reportRepo.countByProjectIdAndTargetTypeAndTargetId(
-        projectId, targetType, targetId);
+    long count = reportRepo.countByTemplateAndProjectIdAndTargetTypeAndTargetId(
+        template, projectId, targetType, targetId);
     assertResourceExisted(count <= 0, REPORT_REPEATED_T, new Object[]{targetType, targetId});
     ActivityResource resource = commonQuery.checkAndFindActivityResource(targetType, targetId);
     assertTrue(projectId.equals(resource.getProjectId()),

--- a/service/core/src/main/java/cloud/xcan/angus/core/tester/domain/report/ReportRepo.java
+++ b/service/core/src/main/java/cloud/xcan/angus/core/tester/domain/report/ReportRepo.java
@@ -26,8 +26,8 @@ public interface ReportRepo extends BaseRepository<Report, Long>, NameJoinReposi
 
   long countByProjectIdAndNameAndVersion(Long projectId, String name, String version);
 
-  long countByProjectIdAndTargetTypeAndTargetId(Long projectId, CombinedTargetType targetType,
-      Long targetId);
+  long countByTemplateAndProjectIdAndTargetTypeAndTargetId(ReportTemplate template, Long projectId,
+      CombinedTargetType targetType, Long targetId);
 
   @Modifying
   @Query("UPDATE Report s SET s.auth=?2 WHERE s.id=?1")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Scopes report resource duplicate checks by `template` and updates query/repository signatures and call site accordingly.
> 
> - **Report resource validation**:
>   - Update `ReportQuery.checkAndFindResource(...)` to accept `ReportTemplate` and validate duplicates via `countByTemplateAndProjectIdAndTargetTypeAndTargetId`.
>   - Replace repo method with `ReportRepo.countByTemplateAndProjectIdAndTargetTypeAndTargetId(...)`.
>   - Modify `ReportCmdImpl.add(...)` to pass `report.getTemplate()` when checking resources.
> - **Cleanup**:
>   - Remove unused `ScriptQuery` injection from `ReportQueryImpl`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa579420c5bea452b21ff230534b5306ad51d6f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->